### PR TITLE
grabbing initialValue via subscription

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "rxjs": "^6.5.2"
   },
   "devDependencies": {
+    "@testing-library/react": "^9.3.0",
     "@types/enzyme": "^3.10.3",
     "@types/enzyme-adapter-react-16": "^1.0.5",
     "@types/jest": "^24.0.15",
@@ -71,7 +72,6 @@
     "pretty-quick": "^1.11.1",
     "react": "^16.9.0",
     "react-dom": "^16.8.6",
-    "react-testing-library": "^7.0.1",
     "rxjs": "^6.5.3",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reonomy/reactive-hooks",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "RxJS React Hooks Library",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Rx Hooks
 export * from './use-rx';
-export * from './use-rx-state';
+export { useRxState, useRxStateResult, useRxStateAction } from './use-rx-state';
 export * from './use-rx-effect';
 export * from './use-rx-ajax';
 export * from './use-rx-debounce';

--- a/src/use-rx-ajax.spec.tsx
+++ b/src/use-rx-ajax.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Observable } from 'rxjs/internal/Observable';
 import { Subject } from 'rxjs/internal/Subject';
-import { act } from 'react-testing-library';
+import { act } from '@testing-library/react';
 import { useRxAjax } from './use-rx-ajax';
 
 interface IFoo {

--- a/src/use-rx-debounce.spec.tsx
+++ b/src/use-rx-debounce.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 import { Observable } from 'rxjs/internal/Observable';
 import { of } from 'rxjs/internal/observable/of';
-import { act } from 'react-testing-library';
+import { act } from '@testing-library/react';
 import { useRxDebounce, DEBOUNCE } from './use-rx-debounce';
 
 interface IFoo {
@@ -35,10 +35,14 @@ describe('useRxDebounce()', () => {
     tb.simulate('change', { target: { value: 'foo' } });
 
     const result = fooComp.find('#result');
-    act(() => jest.advanceTimersByTime(DEBOUNCE - 1));
+    act(() => {
+      jest.advanceTimersByTime(DEBOUNCE - 1);
+    });
     expect(result.text()).toContain('None');
 
-    act(() => jest.advanceTimersByTime(1));
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
     expect(result.text()).toContain('foo');
   });
 });

--- a/src/use-rx-effect.spec.tsx
+++ b/src/use-rx-effect.spec.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { mount } from 'enzyme';
 import { Observable } from 'rxjs/internal/Observable';
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
-import { act } from 'react-testing-library';
+import { act } from '@testing-library/react';
 import { useRxEffect } from './use-rx-effect';
 
 interface IFoo {

--- a/src/use-rx-state.spec.tsx
+++ b/src/use-rx-state.spec.tsx
@@ -135,10 +135,12 @@ describe('useRxState()', () => {
   });
 
   describe('hasNext', () => {
-    it('should only be true for BehaviorSubject', () => {
+    it('should be true for all subjects', () => {
       expect(hasNext(new BehaviorSubject<null>(null))).toBe(true);
       expect(hasNext(new ReplaySubject<null>())).toBe(true);
       expect(hasNext(new Subject<null>())).toBe(true);
+    });
+    it('should not be true for observables', () => {
       expect(hasNext(new Observable<null>())).toBe(false);
     });
   });

--- a/src/use-rx-state.spec.tsx
+++ b/src/use-rx-state.spec.tsx
@@ -4,7 +4,9 @@ import { act } from 'react-testing-library';
 import { Observable } from 'rxjs/internal/Observable';
 import { Subject } from 'rxjs/internal/Subject';
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';
-import { useRxState } from './use-rx-state';
+import { ReplaySubject } from 'rxjs/internal/ReplaySubject';
+import { map } from 'rxjs/operators';
+import { useRxState, hasNext, initialObservableValue, UNSET_VALUE } from './use-rx-state';
 
 interface IFoo {
   foo$: Observable<string>;
@@ -129,6 +131,38 @@ describe('useRxState()', () => {
 
       act(() => bar$.next('bob'));
       expect(fooComp.text()).toContain('bob');
+    });
+  });
+
+  describe('hasNext', () => {
+    it('should only be true for BehaviorSubject', () => {
+      expect(hasNext(new BehaviorSubject<null>(null))).toBe(true);
+      expect(hasNext(new ReplaySubject<null>())).toBe(true);
+      expect(hasNext(new Subject<null>())).toBe(true);
+      expect(hasNext(new Observable<null>())).toBe(false);
+    });
+  });
+
+  describe('initialObservableValue', () => {
+    it('should provide initial value for BehaviorSubject', () => {
+      expect(initialObservableValue(new BehaviorSubject<null>(null))).toBe(null);
+    });
+    it('should unset for non-BehaviorSubjects', () => {
+      expect(initialObservableValue(new ReplaySubject<null>())).toBe(UNSET_VALUE);
+      expect(initialObservableValue(new Subject<null>())).toBe(UNSET_VALUE);
+      expect(initialObservableValue(new Observable<null>())).toBe(UNSET_VALUE);
+    });
+    it('should handle the piped scenario', () => {
+      expect(initialObservableValue(new BehaviorSubject<null>(null).pipe(map(value => value)))).toBe(null);
+    });
+    it('should handle the piped scenario after the value has been changed', () => {
+      const behaviorSubject$ = new BehaviorSubject<any>(null);
+
+      const piped$ = behaviorSubject$.pipe(map(value => value));
+
+      behaviorSubject$.next('check');
+
+      expect(initialObservableValue(piped$)).toBe('check');
     });
   });
 });

--- a/src/use-rx-state.spec.tsx
+++ b/src/use-rx-state.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { act } from 'react-testing-library';
+import { act } from '@testing-library/react';
 import { Observable } from 'rxjs/internal/Observable';
 import { Subject } from 'rxjs/internal/Subject';
 import { BehaviorSubject } from 'rxjs/internal/BehaviorSubject';

--- a/src/use-rx-state.ts
+++ b/src/use-rx-state.ts
@@ -22,11 +22,11 @@ export function hasNext<T>(
  */
 
 // since we don't know what initial observable value is
-// we use a Symbol to indicate that it is nothing with certainty
-export const UNSET_VALUE = Symbol('unset');
+// we use a unique object pointer to indicate "no initial value" with certainty
+export const UNSET_VALUE = {};
 
-export function initialObservableValue<T>(observable$: Observable<T>): T | symbol {
-  let initialValue: T | symbol = UNSET_VALUE;
+export function initialObservableValue<T>(observable$: Observable<T>): T | {} {
+  let initialValue: T | {} = UNSET_VALUE;
   const unsubscribe$ = new Subject<void>();
 
   observable$.pipe(takeUntil(unsubscribe$)).subscribe(mostRecentValueIsSynchronousHere => {

--- a/src/use-rx-state.ts
+++ b/src/use-rx-state.ts
@@ -63,25 +63,26 @@ export function useRxState<S extends Observable<any> | Subject<any> | BehaviorSu
   : never {
   const initObj = useMemo(() => {
     const initVal = initialObservableValue(subject$);
+    const hadInitVal = initVal !== UNSET_VALUE;
+
     return {
       isSubject: hasNext(subject$),
       initVal,
-      hasInitVal: initVal !== UNSET_VALUE
+      hadInitVal,
+      isNext: !hadInitVal
     };
   }, [subject$]);
-
-  const nextObj: { isNext: boolean } = useMemo(() => ({ isNext: !initObj.hasInitVal }), [subject$]);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const observer = useMemo(() => new MutableObserver(), [subject$]);
 
-  const [value, setValue] = useState(() => (initObj.hasInitVal ? initObj.initVal : undefined));
+  const [value, setValue] = useState(() => (initObj.hadInitVal ? initObj.initVal : undefined));
 
   observer.setNext(function(nextValue) {
-    if (nextObj.isNext) {
+    if (initObj.isNext) {
       setValue(nextValue);
     } else {
-      nextObj.isNext = true;
+      initObj.isNext = true;
       delete initObj.initVal; // eliminate reference after using
     }
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,11 +11,6 @@
     "module": "commonjs",
     "jsx": "react"
   },
-  "include": [
-    "./src/index.ts"
-  ],
-  "exclude": [
-    "node_modules",
-    "**/*.spec.ts"
-  ]
+  "include": ["./src/index.ts"],
+  "exclude": ["node_modules", "**/*.spec.ts", "**/*.spec.tsx"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -98,10 +98,17 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.4.3", "@babel/runtime@^7.4.5":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.4.5":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.0.tgz#4fc1d642a9fd0299754e8b5de62c631cf5568205"
   integrity sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.6.0", "@babel/runtime@^7.6.2":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
+  integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
   dependencies:
     regenerator-runtime "^0.13.2"
 
@@ -306,6 +313,27 @@
   resolved "https://registry.yarnpkg.com/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
   integrity sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==
 
+"@testing-library/dom@^6.3.0":
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.8.1.tgz#47b4e0cc0742302fc9d122ac43010e6fc60bee65"
+  integrity sha512-b+Q4wryafqsSTFBV14cc5xqhN/OVB9oMeUQvZwy1kVx+kdqs4zQAcyvCsFkdcqx7NxibWpUN/fBIUaqyAEhitw==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    "@sheerun/mutationobserver-shim" "^0.3.2"
+    "@types/testing-library__dom" "^6.0.0"
+    aria-query "3.0.0"
+    pretty-format "^24.9.0"
+    wait-for-expect "^3.0.0"
+
+"@testing-library/react@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.3.0.tgz#1dabf46d1ea018a1c89acecc0e7b86859b34c0f8"
+  integrity sha512-FTPCwmLo0tLtP50Au2uGz4/N1BcJTnBx4StDVHZ47zPMEj1/+J2rk/RTj8SLoHRKWCtcmhN4wRmudOXQNP29/w==
+  dependencies:
+    "@babel/runtime" "^7.6.0"
+    "@testing-library/dom" "^6.3.0"
+    "@types/testing-library__react" "^9.1.0"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -418,6 +446,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.2.tgz#0e58ae66773d7fd7c372a493aff740878ec9ceaa"
   integrity sha512-f8JzJNWVhKtc9dg/dyDNfliTKNOJSLa7Oht/ElZdF/UbMUmAH3rLmAk3ODNjw0mZajDEgatA03tRjB4+Dp/tzA==
 
+"@types/react-dom@*":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.2.tgz#90f9e6c161850be1feb31d2f448121be2a4f3b47"
+  integrity sha512-hgPbBoI1aTSTvZwo8HYw35UaTldW6n2ETLvHAcfcg1FaOuBV3olmyCe5eMpx2WybWMBPv0MdU2t5GOcQhP+3zA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^16.8.23":
   version "16.9.2"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.2.tgz#6d1765431a1ad1877979013906731aae373de268"
@@ -430,6 +465,21 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/testing-library__dom@*", "@types/testing-library__dom@^6.0.0":
+  version "6.5.3"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__dom/-/testing-library__dom-6.5.3.tgz#4a33e91055994c9f08981253edec44c85f4dd7f0"
+  integrity sha512-E/LSnbzo25gCLy/YOHKY9KJ+rfI8hy5cfbScyZqVuFw9CUMn1faWEDnxMcVHgjAbWtTStfllB8TwNKCx8bAKeA==
+  dependencies:
+    pretty-format "^24.3.0"
+
+"@types/testing-library__react@^9.1.0":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-9.1.2.tgz#e33af9124c60a010fc03a34eff8f8a34a75c4351"
+  integrity sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==
+  dependencies:
+    "@types/react-dom" "*"
+    "@types/testing-library__dom" "*"
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -622,7 +672,7 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-aria-query@^3.0.0:
+aria-query@3.0.0, aria-query@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-3.0.0.tgz#65b3fcc1ca1155a8c9ae64d6eee297f15d5133cc"
   integrity sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=
@@ -1367,16 +1417,6 @@ dom-serializer@~0.1.1:
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
-
-dom-testing-library@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/dom-testing-library/-/dom-testing-library-4.1.1.tgz#615af61bee06db51bd8ecea60c113eba7cb49dda"
-  integrity sha512-PUsG7aY5BJxzulDrOtkksqudRRypcVQF6d4RGAyj9xNwallOFqrNLOyg2QW2mCpFaNVPELX8hBX/wbHQtOto/A==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    "@sheerun/mutationobserver-shim" "^0.3.2"
-    pretty-format "^24.7.0"
-    wait-for-expect "^1.1.1"
 
 domelementtype@1, domelementtype@^1.3.0, domelementtype@^1.3.1:
   version "1.3.1"
@@ -4165,7 +4205,7 @@ prettier@^1.18.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
-pretty-format@^24.7.0, pretty-format@^24.9.0:
+pretty-format@^24.3.0, pretty-format@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-24.9.0.tgz#12fac31b37019a4eea3c11aa9a959eb7628aa7c9"
   integrity sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==
@@ -4315,14 +4355,6 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.2"
     react-is "^16.9.0"
     scheduler "^0.15.0"
-
-react-testing-library@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/react-testing-library/-/react-testing-library-7.0.1.tgz#0cf113bb53a78599f018378f6854e91a52dbf205"
-  integrity sha512-doQkM3/xPcIm22x9jgTkGxU8xqXg4iWvM1WwbbQ7CI5/EMk3DhloYBwMyk+Ywtta3dIAIh9sC7llXoKovf3L+w==
-  dependencies:
-    "@babel/runtime" "^7.4.3"
-    dom-testing-library "^4.1.0"
 
 react@^16.9.0:
   version "16.9.0"
@@ -5310,10 +5342,10 @@ w3c-hr-time@^1.0.1:
   dependencies:
     browser-process-hrtime "^0.1.2"
 
-wait-for-expect@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-1.3.0.tgz#65241ce355425f907f5d127bdb5e72c412ff830c"
-  integrity sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA==
+wait-for-expect@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.0.tgz#d6fbf28959e3b8779dc172fb1ea56bf1e833bf7a"
+  integrity sha512-9LyJL+MugZdcQn5V9PBSEC4d2UPTy1xX2U9wTc6LvG/18qeeYqdE/CgmAQJxc/Vcjs+VzH+wiyIXxz05F3nrpQ==
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
Checking for `.value` on the provided observable to determine whether or not a the observable is a `BehaviorSubject` is insufficient in the case where a value has been derived from an observable.

Here we make this check a little bit more complex.  We check if there's an immediate emission from the observable when it is subscribed to, which will give us the initial value of the observable if the "root" of the observable chain is a BehaviorSubject.

Practically means we avoid an unnecessary extra render with a value of `undefined` when using `useRxState` or `useRxStateResult` on an observable which has been derived from a BehaviorSubject.