### PR TITLE
Guard around window to support SSR

### DIFF
--- a/src/use-rx.ts
+++ b/src/use-rx.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs/internal/Observable';
 import { NextObserver } from 'rxjs/internal/types';
 
 let subscriptionsCount = 0;
-const isDebugMode = /debug$/m.test(window.location.hash);
+const isDebugMode = typeof window !== 'undefined' && /debug$/m.test(window.location.hash);
 const printSubscriptionsCount = isDebugMode
   ? // eslint-disable-next-line no-console
     () => console.debug('%c #', 'color: #40bbc6;', subscriptionsCount)


### PR DESCRIPTION
This supports dev environments where `window` does not exist in the initial build. Happened to come across this while using this in Gatsby https://github.com/reonomy/api-portal.